### PR TITLE
FIX: 不要なdivタグの削除

### DIFF
--- a/ChatApp/templates/auth/base.html
+++ b/ChatApp/templates/auth/base.html
@@ -13,6 +13,5 @@
   </head>
   <body>
     {% block body %}{% endblock %}
-    </div>
   </body>
 </html>


### PR DESCRIPTION
ChatApp/templates/auth/base.html に 不要な `<div>` タグがあったため修正しました